### PR TITLE
feat: Integrate provenance raster generation into flood polygon pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,4 @@ book_gfm/_book/*
 book_gfm/_freeze/*
 book_gfm/early_wips/*
 *.png
-*.html
+*.htmlCLAUDE.md

--- a/OPTIMIZATION_STRATEGY.md
+++ b/OPTIMIZATION_STRATEGY.md
@@ -1,0 +1,312 @@
+# Optimization Strategy for Large Countries (PHL)
+
+## Problem Analysis
+
+**Current Issue:**
+- Philippines: 34.8M dask tasks, 40GB estimated memory → FAILS
+- Root cause: Dense array operations on sparse flood data
+
+**Data Characteristics (GFM):**
+- Values: `255` (nodata), `0` (no-flood), `1` (flood)
+- ~99% of pixels are nodata or 0
+- Only ~0.1-1% are actual flood pixels (value=1)
+- **Current approach treats all 5 billion pixels equally!**
+
+## Critical Findings
+
+### 1. Sparsity NOT Leveraged
+
+```python
+# Current (line 112 in gfm.py)
+stack = stackstac.stack(items, epsg=4326)  # Uses float64, nan fill_value
+```
+
+**Problems:**
+- Uses `dtype=float64` (8 bytes/pixel) by default
+- Uses `fill_value=nan` requiring floating-point
+- 90,451 × 55,405 × 4 dates × 8 bytes = 159GB raw (before compression)
+- Dask creates 34M+ tasks to manage this
+
+### 2. Stackstac Optimization Options
+
+```python
+# Optimized approach
+stack = stackstac.stack(
+    items,
+    epsg=4326,
+    dtype="uint8",          # 1 byte instead of 8!
+    fill_value=255,         # Match GFM's native nodata
+    rescale=False,          # Don't rescale - we know values are 0/1/255
+    chunksize=2048          # Larger chunks = fewer tasks
+)
+```
+
+**Benefits:**
+- 8x memory reduction (uint8 vs float64)
+- Matches native GFM encoding (0/1/255)
+- Fewer dask tasks with larger chunks
+- No rescaling overhead
+
+### 3. Dask Rechunking Strategy
+
+**Current chunks (from PHL output):**
+```
+Chunks: ((155, 1024, 1024, ...), (1011, 1024, 1024, ...))
+```
+
+**Problems:**
+- Many small 1024×1024 chunks
+- Task graph explosion: Each operation creates tasks for EACH chunk
+- 34.8M tasks = operations × number_of_chunks × time_steps
+
+**Solution: Strategic Rechunking**
+
+```python
+# After creating daily composites, before temporal operations
+stack_flood_max = stack_flood_max.groupby("time.date").max()
+
+# RECHUNK before temporal operations
+stack_flood_max = stack_flood_max.chunk({
+    'time': -1,      # Single chunk in time (only 4 dates)
+    'y': 4096,       # Larger spatial chunks
+    'x': 4096
+})
+```
+
+**Why this helps:**
+- Time dimension is small (4 dates) → single chunk eliminates cross-chunk operations
+- Larger spatial chunks (4096 vs 1024) → 16x fewer chunks per dimension
+- Reduces tasks from 34M to ~2M (estimate)
+
+### 4. Persist Intermediate Results
+
+```python
+# After daily composites, BEFORE temporal composite
+stack_flood_max = stack_flood_max.groupby("time.date").max()
+
+# PERSIST to break computation graph
+stack_flood_max = stack_flood_max.persist()  # Compute now, release graph
+logger.info(f"  Persisted daily composites to memory")
+
+# Now temporal operations work on clean, persisted data
+flood_composite = (stack_flood_max == 1).any(dim="time").astype(np.uint8)
+```
+
+**Why this helps:**
+- Breaks the computation graph into stages
+- Daily composites computed once, cached in memory
+- Temporal composite operates on cached data (no task explosion)
+- Memory usage: Only holds 4 dates × spatial_extent (manageable)
+
+## Testing Results
+
+### Attempt 1: dtype optimization (BLOCKED)
+**Finding:** stackstac 0.5.1 validates that `fill_value=nan` requires `dtype=float64`
+- Tried uint8, int16, float32 - all rejected
+- Cannot achieve 8x memory reduction via dtype alone
+
+### Attempt 2: Chunking only (PROGRESS BUT INSUFFICIENT)
+**Results:**
+- Dask tasks: 34.8M → **8.8M** (75% reduction ✅)
+- Memory estimate: 40GB → **5.01GB** (87% reduction ✅)
+- **But still OOM killed** (exit code 137)
+
+**Root cause:** 8.8M tasks + 5GB is still too large for single-pass computation on available memory.
+
+### Attempt 3: Spatial Tiling (✅ SUCCESS!)
+**Implementation:**
+- Created `process_country_tiled()` function
+- Automatically enabled for large countries (PHL, IDN, BRA, etc.)
+- Default tile size: 2.0° × 2.0°
+
+**Results - Philippines (PHL):**
+- 45 tiles created
+- Per-tile metrics:
+  - Tasks: ~50-70k (vs 8.8M for full country)
+  - Memory: 0.12 GB (vs 5GB for full country)
+  - Computation time: 10-25s per tile
+- **Successfully completed** (exit code 0)
+- Polygons combined from all tiles
+
+**Performance improvements:**
+- Task reduction: **130x per tile** (8.8M → ~60k)
+- Memory reduction: **40x per tile** (5GB → 0.12GB)
+- **Scalable to any country size**
+
+## Proposed Implementation
+
+### Phase 1: Low-Hanging Fruit (dtype + chunksize)
+
+```python
+def create_flood_composite(items, bbox, n_latest, mode="latest", return_stack=False):
+    # ... date selection ...
+
+    # OPTIMIZED: Use native GFM encoding
+    stack = stackstac.stack(
+        items,
+        epsg=4326,
+        dtype="uint8",         # 8x memory reduction
+        fill_value=255,        # Native GFM nodata
+        rescale=False,         # No scaling needed
+        chunksize=2048         # Larger chunks
+    )
+
+    # ... rest of function ...
+```
+
+**Expected Impact:**
+- 8x memory reduction
+- 4x fewer dask tasks (larger chunks)
+- Should reduce PHL from 40GB → 5GB, 34M tasks → 8M tasks
+
+### Phase 2: Rechunking Strategy
+
+```python
+# After groupby, RECHUNK
+stack_flood_max = stack_flood_clipped.groupby("time.date").max()
+stack_flood_max = stack_flood_max.rename({"date": "time"})
+stack_flood_max["time"] = stack_flood_max.time.astype("datetime64[ns]")
+
+# RECHUNK: Consolidate time dimension
+stack_flood_max = stack_flood_max.chunk({
+    'time': -1,    # All time in one chunk (only 4 dates)
+    'y': 4096,     # Larger spatial chunks
+    'x': 4096
+})
+logger.info(f"  Rechunked to time:-1, y:4096, x:4096")
+```
+
+**Expected Impact:**
+- Further reduce tasks from 8M → ~500k
+- Eliminate cross-chunk temporal operations
+
+### Phase 3: Persist Strategy (if still needed)
+
+```python
+# After rechunking, optionally PERSIST
+logger.info(f"  Computing daily composites...")
+stack_flood_max = stack_flood_max.persist()
+logger.info(f"  Daily composites persisted to memory")
+
+# Temporal composite on clean persisted data
+flood_composite = (stack_flood_max == 1).any(dim="time").astype(np.uint8)
+```
+
+**Tradeoff:**
+- Requires computing full daily stack (~5GB for PHL)
+- But eliminates task graph completely for final composite
+- Net win if available memory > data size
+
+## Alternative: Spatial Tiling
+
+If memory is still insufficient:
+
+```python
+def process_country_in_tiles(iso3, tile_size=2.0):
+    """Process large countries in lat/lon tiles"""
+    gdf_admin = stratus.codab.load_codab_from_fieldmaps(iso3, 0)
+    full_bbox = gdf_admin.total_bounds
+
+    # Create tiles
+    tiles = create_tiles(full_bbox, tile_size)
+
+    # Process each tile
+    tile_results = []
+    for tile_bbox in tiles:
+        items = query_gfm_stac(tile_bbox, end_date, n_search)
+        flood_composite, dates, _ = create_flood_composite(items, tile_bbox, ...)
+        tile_polygons = raster_to_polygons(flood_composite)
+        tile_results.append(tile_polygons)
+
+    # Merge all tiles
+    return gpd.GeoDataFrame(pd.concat(tile_results, ignore_index=True))
+```
+
+## Testing Plan
+
+1. **JAM baseline**: Verify optimizations don't break small countries
+2. **PHL Phase 1**: Test dtype + chunksize alone
+3. **PHL Phase 2**: Add rechunking if needed
+4. **PHL Phase 3**: Add persist if still needed
+5. **Fallback**: Spatial tiling if memory constrained
+
+## Metrics to Track
+
+```python
+# Add to diagnostic logging
+logger.info(f"  Chunk sizes (MB): {[c.nbytes/1e6 for c in flood_raster.data.blocks.values()]}")
+logger.info(f"  Task graph size: {len(flood_raster.data.__dask_graph__())} tasks")
+logger.info(f"  Estimated memory: {flood_raster.nbytes / 1e9:.2f} GB")
+logger.info(f"  Actual dtype: {flood_raster.dtype}")
+```
+
+## Final Implementation
+
+### Optimizations Applied
+
+**1. Chunking optimization ([gfm.py:114-122](src/ds_flood_gfm/datasources/gfm.py#L114-L122)):**
+```python
+stack = stackstac.stack(
+    items,
+    epsg=4326,
+    rescale=False,         # Skip unnecessary rescaling operations
+    chunksize=2048         # 4x larger chunks (vs default 1024)
+)
+```
+
+**2. Strategic rechunking ([gfm.py:138-146](src/ds_flood_gfm/datasources/gfm.py#L138-L146)):**
+```python
+stack_flood_max = stack_flood_max.chunk({
+    'time': -1,    # Single chunk for time dimension (4 dates)
+    'y': 4096,     # Larger spatial chunks
+    'x': 4096
+})
+```
+
+**3. Spatial tiling for large countries ([gfm.py:257-365](src/ds_flood_gfm/datasources/gfm.py#L257-L365)):**
+- Automatic detection of large countries
+- 2.0° × 2.0° tiles (configurable)
+- Sequential tile processing with polygon merging
+- Note: Provenance raster not yet supported for tiled processing
+
+### Usage
+
+**Small countries (JAM, HTI, CUB):**
+```bash
+uv run python scripts/04_generate_flood_polygons.py \
+    --iso3 JAM \
+    --end-date 2025-11-12 \
+    --n-latest 4 \
+    --flood-mode cumulative
+```
+
+**Large countries (PHL, IDN, BRA, etc.):**
+```bash
+# Tiling automatically enabled
+uv run python scripts/04_generate_flood_polygons.py \
+    --iso3 PHL \
+    --end-date 2025-11-12 \
+    --n-latest 4 \
+    --flood-mode cumulative
+
+# Or manually control tiling
+uv run python scripts/04_generate_flood_polygons.py \
+    --iso3 PHL \
+    --use-tiling \
+    --tile-size 2.0 \
+    --end-date 2025-11-12 \
+    --n-latest 4 \
+    --flood-mode cumulative
+```
+
+### Known Limitations
+
+1. **Provenance rasters**: Not yet supported for tiled processing (would require mosaicking tile stacks)
+2. **Tile boundaries**: Polygons may be split at tile boundaries (could implement buffering/merging)
+3. **Sequential processing**: Tiles processed one at a time (could parallelize for faster execution)
+
+## References
+
+- [stackstac dtype optimization](https://stackstac.readthedocs.io/en/stable/api/main/stackstac.stack.html)
+- [GFM band encoding](https://extwiki.eodc.eu/GFM/PUM/TechnicalOverview)
+- [Dask rechunking best practices](https://docs.dask.org/en/stable/array-chunks.html)

--- a/OPTIMIZATION_STRATEGY.md
+++ b/OPTIMIZATION_STRATEGY.md
@@ -264,10 +264,16 @@ stack_flood_max = stack_flood_max.chunk({
 ```
 
 **3. Spatial tiling for large countries ([gfm.py:257-365](src/ds_flood_gfm/datasources/gfm.py#L257-L365)):**
-- Automatic detection of large countries
+- Automatic detection of large countries (PHL, IDN, BRA, USA, CAN, RUS, CHN, AUS)
 - 2.0° × 2.0° tiles (configurable)
 - Sequential tile processing with polygon merging
-- Note: Provenance raster not yet supported for tiled processing
+- Auto-enabled in [scripts/04_generate_flood_polygons.py:74-78](scripts/04_generate_flood_polygons.py#L74-L78)
+
+**4. Provenance raster integration ([gfm.py:406-440, scripts/04:133-153](src/ds_flood_gfm/datasources/gfm.py#L406-L440)):**
+- Tracks last observation date per flood pixel
+- Uses argmax over time dimension to find most recent flood date
+- Output: int16 raster with date indices + metadata mapping
+- Added to both COG files (as xarray attrs) and flood polygons (via exactextract)
 
 ### Usage
 
@@ -299,11 +305,77 @@ uv run python scripts/04_generate_flood_polygons.py \
     --flood-mode cumulative
 ```
 
+### Provenance Raster Performance
+
+**What it does:**
+- Tracks the last observation date for each flooded pixel
+- Creates an integer index raster mapping pixels to their observation dates
+- Stores date mapping as metadata in COG files (GeoTIFF tags via xarray attrs)
+- Adds provenance dates to flood polygons using exactextract modal statistics
+
+**Performance impact (Jamaica, 392 polygons, 7378×11639 raster):**
+- Provenance raster computation: ~11s (argmax over time dimension)
+- Add to flood polygons: ~0.3s (exactextract modal operation)
+- COG metadata storage: negligible (stored as xarray DataArray attributes)
+- **Total overhead: ~11.3s** (manageable for most workflows)
+
+**Memory characteristics:**
+- Provenance raster: int16 dtype (2 bytes per pixel)
+- Jamaica example: 7378 × 11639 × 2 bytes = ~0.17 GB
+- Lazy by default, computed once and reused for both COG and polygons
+- Cast to int16 to avoid GeoTIFF encoding issues ([commit b7ed963](https://github.com/OCHA-DAP/ds-flood-gfm/commit/b7ed963))
+
+**Integration points:**
+1. **COG files**: Metadata stored as xarray attrs → GeoTIFF tags
+   - `date_mapping`: JSON mapping of indices to ISO dates
+   - `created_date`: Timestamp of generation
+2. **Flood polygons**: Two new columns added via exactextract
+   - `prov_idx`: Integer index (0, 1, 2, ... for dates; -1 for no data)
+   - `prov_date`: ISO date string (YYYY-MM-DD)
+
+**Limitation**: Only works with non-tiled processing (see Known Limitations below)
+
+### Production Metrics
+
+**Jamaica (JAM) - Standard Processing with Provenance:**
+- End date: 2025-11-26, 3 dates (2025-11-20, 2025-11-22, 2025-11-23)
+- Mode: cumulative
+- Raster dimensions: 7378 × 11639
+- Output: 392 flood polygons
+
+**Timing breakdown:**
+- Flood composite computation: 13.0s
+- Polygon conversion: ~1s
+- Provenance raster computation: 11.0s
+- Add provenance to polygons: 0.3s
+- Upload to blob: ~2s
+- **Total runtime: ~37s**
+
+**Provenance distribution:**
+- 391 polygons (99.7%) from 2025-11-22 (most recent)
+- 1 polygon (0.3%) from 2025-11-20 (persistent flooding)
+
+**Philippines (PHL) - Tiled Processing (without provenance):**
+- 45 tiles at 2.0° × 2.0°
+- Per-tile metrics:
+  - Tasks: 50-70k (vs 8.8M for full country)
+  - Memory: 0.12 GB per tile (vs 5GB for full country)
+  - Computation: 10-25s per tile
+- **Successfully completes** where non-tiled approach OOM kills
+- Task reduction: **130x per tile**
+- Memory reduction: **40x per tile**
+
 ### Known Limitations
 
-1. **Provenance rasters**: Not yet supported for tiled processing (would require mosaicking tile stacks)
+1. **Provenance rasters**: Not yet supported for tiled processing
+   - Reason: Would require mosaicking tile stacks before argmax operation
+   - Workaround: Use non-tiled processing for countries requiring provenance
+   - Future: Could implement tile stack mosaicking for large countries
 2. **Tile boundaries**: Polygons may be split at tile boundaries (could implement buffering/merging)
 3. **Sequential processing**: Tiles processed one at a time (could parallelize for faster execution)
+4. **Phase 3 persist strategy**: Not currently used in production
+   - Spatial tiling achieves similar memory management more effectively
+   - Persist would add ~5GB memory requirement without clear benefit given tiling success
 
 ## References
 

--- a/flood_exposure.py
+++ b/flood_exposure.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.17.5"
+__generated_with = "0.17.7"
 app = marimo.App(width="medium")
 
 
@@ -31,12 +31,8 @@ def _():
     import plotly.express as px
     import re
 
-    GHSL_RASTER_BLOB_PATH_3s = (
-        "ghsl/pop/GHS_POP_E2025_GLOBE_R2023A_4326_3ss_V1_0.tif"
-    )
-    GHSL_RASTER_BLOB_PATH_30s = (
-        "ghsl/pop/GHS_POP_E2025_GLOBE_R2023A_4326_30ss_V1_0.tif"
-    )
+    GHSL_RASTER_BLOB_PATH_3s = "ghsl/pop/GHS_POP_E2025_GLOBE_R2023A_4326_3ss_V1_0.tif"
+    GHSL_RASTER_BLOB_PATH_30s = "ghsl/pop/GHS_POP_E2025_GLOBE_R2023A_4326_30ss_V1_0.tif"
     # JRC_FLOOD_ZIP = "ds-flood-gfm/processed/polygon/CUB_20251102_20251103_20251104_20251105_nopop_cumulative.shp.zip"
     # JRC_FLOOD_SHP = "data/data.shp"
 
@@ -65,7 +61,7 @@ def _(mo):
 @app.cell
 def _(mo):
     iso3_dropdown = mo.ui.dropdown(
-        label="Select a country", options=["CUB", "HTI", "JAM"], value="HTI"
+        label="Select a country", options=["CUB", "HTI", "JAM", "PHL"], value="HTI"
     )
     adm_dropdown = mo.ui.dropdown(
         label="Select an admin level", options=[0, 1, 2, 3], value=3
@@ -100,13 +96,11 @@ def _(mo, stratus):
     def get_adm(iso3, adm_level):
         return stratus.codab.load_codab_from_fieldmaps(iso3, adm_level)
 
-
     @mo.persistent_cache
     def get_pop(blob_path):
         return stratus.open_blob_cog(blob_path, container_name="raster").squeeze(
             drop=True
         )
-
 
     @mo.persistent_cache
     def get_flood(flood_zip, flood_shp):
@@ -275,9 +269,7 @@ def _(
 
         # Update legend title and format number in title with comma
         title = parse_flood_string(shp_dropdown.value)
-        title_suffix = (
-            f" - ({buffer_dropdown.value}m buffer) - {total_exposed} people"
-        )
+        title_suffix = f" - ({buffer_dropdown.value}m buffer) - {total_exposed} people"
         fig.update_layout(title=title + title_suffix)
     else:
         gdf_plot = (
@@ -354,9 +346,7 @@ def _(
     buffer_distance = buffer_dropdown.value  # In meters, set to 0 for no buffer
 
     # Find and extract the admin region
-    admin_region = gdf_result[
-        gdf_result[f"adm{adm_dropdown.value}_name"] == admin_name
-    ]
+    admin_region = gdf_result[gdf_result[f"adm{adm_dropdown.value}_name"] == admin_name]
 
     # Clip to admin boundary
     pop_clipped = da_clip_r.rio.clip(admin_region.geometry, drop=True)
@@ -370,16 +360,16 @@ def _(
     _fig, ax = plt.subplots(figsize=(10, 8))
 
     # Create custom colormap: white for zero, then Blues
-    colors = ['white'] + [plt.cm.Blues(i) for i in np.linspace(0.3, 1.0, 256)]
+    colors = ["white"] + [plt.cm.Blues(i) for i in np.linspace(0.3, 1.0, 256)]
     custom_cmap = mcolors.ListedColormap(colors)
 
     pop_clipped_plot = pop_clipped.where(pop_clipped > 0)  # Mask zeros
     pop_clipped_plot.plot(
-        ax=ax, 
-        cmap=custom_cmap, 
-        alpha=0.7, 
-        add_colorbar=True, 
-        norm=mcolors.LogNorm(vmin=0.1, vmax=pop_clipped.max())
+        ax=ax,
+        cmap=custom_cmap,
+        alpha=0.7,
+        add_colorbar=True,
+        norm=mcolors.LogNorm(vmin=0.1, vmax=pop_clipped.max()),
     )
 
     admin_region.boundary.plot(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "scipy>=1.16.2",
     "rasterstats>=0.20.0",
     "adjusttext>=1.3.0",
+    "marimo>=0.17.7",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,7 @@ where = ["src"]
 [tool.black]
 line-length = 88
 target-version = ['py312']
+
+[tool.marimo.runtime]
+output_max_bytes = 15_000_000
+

--- a/scripts/02_generate_affected_population_choropleths.py
+++ b/scripts/02_generate_affected_population_choropleths.py
@@ -60,6 +60,7 @@ from ds_flood_gfm.country_config import (
     get_bbox,
     GHSL_RASTER_BLOB_PATH,
 )
+from ds_flood_gfm.datasources.gfm import add_provenance_to_polygons
 
 load_dotenv()
 
@@ -774,70 +775,40 @@ def create_map_from_cache(
             colors = generate_rdylgn_colors(len(unique_dates))
             date_to_color = {i: colors[i] for i in range(len(unique_dates))}
 
-            # Write provenance raster to temp file for exactextract
-            # exactextract needs a file path, not in-memory array
-            # Get provenance as numpy array (handle both xarray and numpy)
+            # Create date mapping for add_provenance_to_polygons function
+            date_mapping = {
+                i: str(pd.Timestamp(date))[:10]
+                for i, date in enumerate(unique_dates)
+            }
+            date_mapping[-1] = "No Data"
+
+            # Convert provenance to xarray if needed
             if isinstance(provenance_indexed, xr.DataArray):
-                prov_data = provenance_indexed.values.astype("int16")
-                x_min, x_max = float(provenance_indexed.x.min()), float(
-                    provenance_indexed.x.max()
-                )
-                y_min, y_max = float(provenance_indexed.y.min()), float(
-                    provenance_indexed.y.max()
-                )
+                prov_xr = provenance_indexed
             else:
-                # Already a numpy array (from cache)
-                prov_data = provenance_indexed.astype("int16")
-                # Get bounds from provenance_target
-                x_min, x_max = float(provenance_target.x.min()), float(
-                    provenance_target.x.max()
-                )
-                y_min, y_max = float(provenance_target.y.min()), float(
-                    provenance_target.y.max()
+                # Convert numpy array to xarray with coordinates from provenance_target
+                prov_xr = xr.DataArray(
+                    provenance_indexed,
+                    coords=provenance_target.coords,
+                    dims=provenance_target.dims
                 )
 
-            # Create affine transform from coordinates
-            height, width = prov_data.shape
-            transform = from_bounds(x_min, y_min, x_max, y_max, width, height)
-
-            # Write to temporary file
-            with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
-                tmp_raster_path = tmp.name
-
-            with rasterio.open(
-                tmp_raster_path,
-                "w",
-                driver="GTiff",
-                height=height,
-                width=width,
-                count=1,
-                dtype="int16",
-                crs="EPSG:4326",
-                transform=transform,
-            ) as dst:
-                dst.write(prov_data, 1)
-
-            # Use exactextract to get mode of provenance_indexed for each polygon
-            # This is MUCH faster than rasterstats!
-            modal_prov = exactextract.exact_extract(
-                tmp_raster_path,
+            # Use refactored function to add provenance to admin boundaries
+            gdf_admin = add_provenance_to_polygons(
                 gdf_admin,
-                ["mode"],
-                include_cols=[f"adm{adm_level}_id"],
-                output="pandas",
+                prov_xr,
+                date_mapping,
+                id_col=f"adm{adm_level}_id"
             )
 
-            # Clean up temp file
-            os.unlink(tmp_raster_path)
-
-            # Map results to colors
+            # Map provenance indices to colors for visualization
             prov_colors = []
-            for _, row in modal_prov.iterrows():
-                mode_val = row["mode"]
-                if pd.isna(mode_val) or mode_val == -1:
+            for _, row in gdf_admin.iterrows():
+                prov_idx = row["prov_idx"]
+                if pd.isna(prov_idx) or prov_idx == -1:
                     prov_colors.append("lightgray")
                 else:
-                    prov_colors.append(date_to_color.get(int(mode_val), "lightgray"))
+                    prov_colors.append(date_to_color.get(int(prov_idx), "lightgray"))
 
             gdf_admin["prov_color"] = prov_colors
 
@@ -1622,70 +1593,40 @@ def create_map_from_stac(
             colors = generate_rdylgn_colors(len(unique_dates))
             date_to_color = {i: colors[i] for i in range(len(unique_dates))}
 
-            # Write provenance raster to temp file for exactextract
-            # exactextract needs a file path, not in-memory array
-            # Get provenance as numpy array (handle both xarray and numpy)
+            # Create date mapping for add_provenance_to_polygons function
+            date_mapping = {
+                i: str(pd.Timestamp(date))[:10]
+                for i, date in enumerate(unique_dates)
+            }
+            date_mapping[-1] = "No Data"
+
+            # Convert provenance to xarray if needed
             if isinstance(provenance_indexed, xr.DataArray):
-                prov_data = provenance_indexed.values.astype("int16")
-                x_min, x_max = float(provenance_indexed.x.min()), float(
-                    provenance_indexed.x.max()
-                )
-                y_min, y_max = float(provenance_indexed.y.min()), float(
-                    provenance_indexed.y.max()
-                )
+                prov_xr = provenance_indexed
             else:
-                # Already a numpy array (from cache)
-                prov_data = provenance_indexed.astype("int16")
-                # Get bounds from provenance_target
-                x_min, x_max = float(provenance_target.x.min()), float(
-                    provenance_target.x.max()
-                )
-                y_min, y_max = float(provenance_target.y.min()), float(
-                    provenance_target.y.max()
+                # Convert numpy array to xarray with coordinates from provenance_target
+                prov_xr = xr.DataArray(
+                    provenance_indexed,
+                    coords=provenance_target.coords,
+                    dims=provenance_target.dims
                 )
 
-            # Create affine transform from coordinates
-            height, width = prov_data.shape
-            transform = from_bounds(x_min, y_min, x_max, y_max, width, height)
-
-            # Write to temporary file
-            with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
-                tmp_raster_path = tmp.name
-
-            with rasterio.open(
-                tmp_raster_path,
-                "w",
-                driver="GTiff",
-                height=height,
-                width=width,
-                count=1,
-                dtype="int16",
-                crs="EPSG:4326",
-                transform=transform,
-            ) as dst:
-                dst.write(prov_data, 1)
-
-            # Use exactextract to get mode of provenance_indexed for each polygon
-            # This is MUCH faster than rasterstats!
-            modal_prov = exactextract.exact_extract(
-                tmp_raster_path,
+            # Use refactored function to add provenance to admin boundaries
+            gdf_admin = add_provenance_to_polygons(
                 gdf_admin,
-                ["mode"],
-                include_cols=[f"adm{adm_level}_id"],
-                output="pandas",
+                prov_xr,
+                date_mapping,
+                id_col=f"adm{adm_level}_id"
             )
 
-            # Clean up temp file
-            os.unlink(tmp_raster_path)
-
-            # Map results to colors
+            # Map provenance indices to colors for visualization
             prov_colors = []
-            for _, row in modal_prov.iterrows():
-                mode_val = row["mode"]
-                if pd.isna(mode_val) or mode_val == -1:
+            for _, row in gdf_admin.iterrows():
+                prov_idx = row["prov_idx"]
+                if pd.isna(prov_idx) or prov_idx == -1:
                     prov_colors.append("lightgray")
                 else:
-                    prov_colors.append(date_to_color.get(int(mode_val), "lightgray"))
+                    prov_colors.append(date_to_color.get(int(prov_idx), "lightgray"))
 
             gdf_admin["prov_color"] = prov_colors
 

--- a/scripts/04_generate_flood_polygons.py
+++ b/scripts/04_generate_flood_polygons.py
@@ -79,7 +79,13 @@ def main():
         items, bbox, args.n_latest, mode=args.flood_mode, return_stack=True
     )
 
-    flood_polygons = raster_to_polygons(flood_composite)
+    logger.info("Converting flood raster to polygons...")
+    try:
+        flood_polygons = raster_to_polygons(flood_composite)
+        logger.info(f"✅ Polygon conversion complete")
+    except Exception as e:
+        logger.error(f"❌ Polygon conversion failed: {e}")
+        raise
 
     if len(flood_polygons) == 0:
         logger.warning("No polygons created")

--- a/scripts/04_generate_flood_polygons.py
+++ b/scripts/04_generate_flood_polygons.py
@@ -25,6 +25,7 @@ def main():
     )
     parser.add_argument('--end-date', required=True, help='End date (YYYY-MM-DD)')
     parser.add_argument('--n-latest', type=int, default=4, help='Number of days to look back (default: 4)')
+    parser.add_argument('--n-search', type=int, default=15, help='Search window in days (default: 15)')
     parser.add_argument('--iso3', required=True, help='Country ISO3 code (JAM, HTI, CUB)')
     parser.add_argument('--flood-mode', choices=['latest', 'cumulative'], default='latest', help='Flood composite mode')
     parser.add_argument('--output-dir', type=Path, default=Path('outputs/polygons'), help='Output directory')
@@ -37,12 +38,13 @@ def main():
     logger.info(f"Country: {args.iso3}")
     logger.info(f"End date: {args.end_date}")
     logger.info(f"Days back: {args.n_latest}")
+    logger.info(f"Search window: {args.n_search}")
     logger.info(f"Mode: {args.flood_mode}")
     logger.info("=" * 60)
-    
+
     gdf_admin = stratus.codab.load_codab_from_fieldmaps(args.iso3, 0)
     bbox = gdf_admin.total_bounds
-    items = query_gfm_stac(bbox, args.end_date)
+    items = query_gfm_stac(bbox, args.end_date, args.n_search)
     
     if len(items) == 0:
         logger.error("No STAC items found for the specified criteria")

--- a/scripts/04_generate_flood_polygons.py
+++ b/scripts/04_generate_flood_polygons.py
@@ -1,11 +1,16 @@
 import argparse
 import logging
+import tempfile
 from pathlib import Path
+import numpy as np
+import rasterio
+from rasterio.transform import from_bounds
 import ocha_stratus as stratus
 from dotenv import load_dotenv
 
 from ds_flood_gfm.datasources.gfm import (
     create_flood_composite,
+    create_provenance_raster,
     export_polygons,
     query_gfm_stac,
     raster_to_polygons,
@@ -13,25 +18,44 @@ from ds_flood_gfm.datasources.gfm import (
 from ds_flood_gfm.geo_utils import generate_cache_key
 
 logging.basicConfig(
-    level=logging.INFO, 
-    format='%(asctime)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 load_dotenv()
 
+
 def main():
     parser = argparse.ArgumentParser(
-        description='Generate flood polygons from GFM STAC data'
+        description="Generate flood polygons from GFM STAC data"
     )
-    parser.add_argument('--end-date', required=True, help='End date (YYYY-MM-DD)')
-    parser.add_argument('--n-latest', type=int, default=4, help='Number of days to look back (default: 4)')
-    parser.add_argument('--n-search', type=int, default=15, help='Search window in days (default: 15)')
-    parser.add_argument('--iso3', required=True, help='Country ISO3 code (JAM, HTI, CUB)')
-    parser.add_argument('--flood-mode', choices=['latest', 'cumulative'], default='latest', help='Flood composite mode')
-    parser.add_argument('--output-dir', type=Path, default=Path('outputs/polygons'), help='Output directory')
-    
+    parser.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--n-latest",
+        type=int,
+        default=4,
+        help="Number of days to look back (default: 4)",
+    )
+    parser.add_argument(
+        "--n-search", type=int, default=15, help="Search window in days (default: 15)"
+    )
+    parser.add_argument(
+        "--iso3", required=True, help="Country ISO3 code (JAM, HTI, CUB)"
+    )
+    parser.add_argument(
+        "--flood-mode",
+        choices=["latest", "cumulative"],
+        default="latest",
+        help="Flood composite mode",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/polygons"),
+        help="Output directory",
+    )
+
     args = parser.parse_args()
-    
+
     logger.info("=" * 60)
     logger.info("GFM FLOOD POLYGON GENERATOR")
     logger.info("=" * 60)
@@ -45,38 +69,64 @@ def main():
     gdf_admin = stratus.codab.load_codab_from_fieldmaps(args.iso3, 0)
     bbox = gdf_admin.total_bounds
     items = query_gfm_stac(bbox, args.end_date, args.n_search)
-    
+
     if len(items) == 0:
         logger.error("No STAC items found for the specified criteria")
         return
-    
-    flood_composite, unique_dates = create_flood_composite(
-        items, bbox, args.n_latest, mode=args.flood_mode
+
+    # Create flood composite with stack for provenance
+    flood_composite, unique_dates, stack_flood_max = create_flood_composite(
+        items, bbox, args.n_latest, mode=args.flood_mode, return_stack=True
     )
 
     flood_polygons = raster_to_polygons(flood_composite)
-    
+
     if len(flood_polygons) == 0:
         logger.warning("No polygons created")
         return
-    
-    date_str = args.end_date.replace('-', '')
+
+    date_str = args.end_date.replace("-", "")
     filename_base = f"{args.iso3.lower()}_flood_{args.flood_mode}_{date_str}"
     output_path = args.output_dir / filename_base
-    
+
     output_path = generate_cache_key(args.iso3, unique_dates, None, args.flood_mode)
-    export_polygons(
-        flood_polygons, 
-        output_path,
-        local=False,
-        blob=True
-    )
-    
+    export_polygons(flood_polygons, output_path, local=False, blob=True)
+
+    # Generate and upload provenance raster
+    logger.info("\n" + "=" * 60)
+    logger.info("GENERATING PROVENANCE RASTER")
     logger.info("=" * 60)
+
+    provenance_idx, date_mapping = create_provenance_raster(
+        stack_flood_max, unique_dates
+    )
+
+    # Compute the provenance raster
+    logger.info("Computing provenance raster...")
+    prov_computed = provenance_idx.compute()
+    logger.info(f"✅ Provenance raster computed: {prov_computed.shape}")
+
+    # Create filename based on cache key
+    prov_filename = f"{output_path}_provenance.tif"
+    blob_path = f"ds-flood-gfm/processed/provenance_raster/{prov_filename}"
+
+    # Upload to blob as COG (stratus expects xarray DataArray)
+    logger.info(f"Uploading provenance raster to: {blob_path}")
+    stratus.upload_cog_to_blob(
+        prov_computed, blob_path, container_name="projects", stage="dev"
+    )
+    logger.info(f"✅ Provenance raster uploaded")
+
+    # Log date mapping for reference
+    logger.info("\nProvenance date mapping:")
+    for idx, date in date_mapping.items():
+        logger.info(f"  {idx}: {date}")
+
+    logger.info("\n" + "=" * 60)
     logger.info("FLOOD POLYGON GENERATION COMPLETE")
     logger.info("=" * 60)
     logger.info(f"   Polygons created: {len(flood_polygons)}")
-
+    logger.info(f"   Provenance raster saved to blob: {blob_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/04_generate_flood_polygons.py
+++ b/scripts/04_generate_flood_polygons.py
@@ -148,7 +148,11 @@ def main():
         # Compute the provenance raster
         logger.info("Computing provenance raster...")
         prov_computed = provenance_idx.compute()
-        logger.info(f"✅ Provenance raster computed: {prov_computed.shape}")
+
+        # IMPORTANT: Cast to int16 for proper GeoTIFF encoding
+        # provenance_idx values are integers (-1, 0, 1, 2, ...) but inherit float64 dtype
+        prov_computed = prov_computed.astype(np.int16)
+        logger.info(f"✅ Provenance raster computed: {prov_computed.shape}, dtype={prov_computed.dtype}")
 
         # Create filename based on cache key
         prov_filename = f"{output_path}_provenance.tif"

--- a/scripts/04_generate_flood_polygons.py
+++ b/scripts/04_generate_flood_polygons.py
@@ -11,6 +11,7 @@ import ocha_stratus as stratus
 from dotenv import load_dotenv
 
 from ds_flood_gfm.datasources.gfm import (
+    add_provenance_to_polygons,
     create_flood_composite,
     create_provenance_raster,
     export_polygons,
@@ -121,7 +122,7 @@ def main():
         logger.info("Converting flood raster to polygons...")
         try:
             flood_polygons = raster_to_polygons(flood_composite)
-            logger.info(f"✅ Polygon conversion complete")
+            logger.info(f"✅ Polygon conversion complete: {len(flood_polygons)} polygons")
         except Exception as e:
             logger.error(f"❌ Polygon conversion failed: {e}")
             raise
@@ -130,6 +131,28 @@ def main():
         logger.warning("No polygons created")
         return
 
+    # Add provenance to flood polygons (only for non-tiled processing)
+    if stack_flood_max is not None:
+        logger.info("\n" + "=" * 60)
+        logger.info("ADDING PROVENANCE TO FLOOD POLYGONS")
+        logger.info("=" * 60)
+
+        # Create provenance raster (lazy)
+        provenance_idx, date_mapping = create_provenance_raster(
+            stack_flood_max, unique_dates
+        )
+
+        # Compute provenance raster
+        logger.info("Computing provenance raster...")
+        prov_computed = provenance_idx.compute().astype(np.int16)
+        logger.info(f"✅ Provenance raster computed: {prov_computed.shape}")
+
+        # Add provenance dates to flood polygons
+        flood_polygons = add_provenance_to_polygons(
+            flood_polygons, prov_computed, date_mapping
+        )
+        logger.info(f"✅ Added provenance dates to flood polygons")
+
     date_str = args.end_date.replace("-", "")
     filename_base = f"{args.iso3.lower()}_flood_{args.flood_mode}_{date_str}"
     output_path = args.output_dir / filename_base
@@ -137,24 +160,11 @@ def main():
     output_path = generate_cache_key(args.iso3, unique_dates, None, args.flood_mode)
     export_polygons(flood_polygons, output_path, local=False, blob=True)
 
-    # Generate and upload provenance raster (only for non-tiled processing)
+    # Upload provenance raster (already computed above)
     if stack_flood_max is not None:
         logger.info("\n" + "=" * 60)
-        logger.info("GENERATING PROVENANCE RASTER")
+        logger.info("UPLOADING PROVENANCE RASTER")
         logger.info("=" * 60)
-
-        provenance_idx, date_mapping = create_provenance_raster(
-            stack_flood_max, unique_dates
-        )
-
-        # Compute the provenance raster
-        logger.info("Computing provenance raster...")
-        prov_computed = provenance_idx.compute()
-
-        # IMPORTANT: Cast to int16 for proper GeoTIFF encoding
-        # provenance_idx values are integers (-1, 0, 1, 2, ...) but inherit float64 dtype
-        prov_computed = prov_computed.astype(np.int16)
-        logger.info(f"✅ Provenance raster computed: {prov_computed.shape}, dtype={prov_computed.dtype}")
 
         # Add metadata as DataArray attributes (stored as GeoTIFF tags)
         prov_computed.attrs['date_mapping'] = json.dumps(date_mapping)

--- a/scripts/04_generate_flood_polygons.py
+++ b/scripts/04_generate_flood_polygons.py
@@ -1,6 +1,8 @@
 import argparse
+import json
 import logging
 import tempfile
+from datetime import datetime
 from pathlib import Path
 import numpy as np
 import rasterio
@@ -154,6 +156,11 @@ def main():
         prov_computed = prov_computed.astype(np.int16)
         logger.info(f"✅ Provenance raster computed: {prov_computed.shape}, dtype={prov_computed.dtype}")
 
+        # Add metadata as DataArray attributes (stored as GeoTIFF tags)
+        prov_computed.attrs['date_mapping'] = json.dumps(date_mapping)
+        prov_computed.attrs['created_date'] = datetime.now().isoformat()
+        logger.info("✅ Added metadata to provenance raster")
+
         # Create filename based on cache key
         prov_filename = f"{output_path}_provenance.tif"
         blob_path = f"ds-flood-gfm/processed/provenance_raster/{prov_filename}"
@@ -163,7 +170,7 @@ def main():
         stratus.upload_cog_to_blob(
             prov_computed, blob_path, container_name="projects", stage="dev"
         )
-        logger.info(f"✅ Provenance raster uploaded")
+        logger.info(f"✅ Provenance raster uploaded with metadata")
 
         # Log date mapping for reference
         logger.info("\nProvenance date mapping:")

--- a/src/ds_flood_gfm/datasources/gfm.py
+++ b/src/ds_flood_gfm/datasources/gfm.py
@@ -441,32 +441,51 @@ def create_provenance_raster(stack_flood_max: xr.DataArray, unique_dates: np.nda
     return provenance_idx, date_mapping
 
 
-def add_modal_provenance_to_admin(gdf_admin: gpd.GeoDataFrame,
-                                   provenance_idx: xr.DataArray,
-                                   date_mapping: dict,
-                                   admin_level: int = 3) -> gpd.GeoDataFrame:
-    """Add modal (most common) provenance date to admin boundaries.
+def add_provenance_to_polygons(
+    gdf_polygons: gpd.GeoDataFrame,
+    provenance_idx: xr.DataArray,
+    date_mapping: dict,
+    id_col: str = None
+) -> gpd.GeoDataFrame:
+    """Add modal (most common) provenance date to polygons.
 
     Uses exactextract to efficiently calculate the most common provenance date
-    within each administrative boundary.
+    within each polygon. Works for both flood polygons and administrative boundaries.
 
     Parameters
     ----------
-    gdf_admin : gpd.GeoDataFrame
-        Administrative boundaries.
+    gdf_polygons : gpd.GeoDataFrame
+        Polygons (flood polygons, admin boundaries, etc.).
     provenance_idx : xr.DataArray
         Provenance raster with integer indices (should be computed, not lazy).
     date_mapping : dict
         Mapping from integer indices to date strings.
-    admin_level : int, default 0
-        Administrative level (0, 1, 2, 3) for column naming.
+    id_col : str, optional
+        Column name to use for merging results back. If None, uses row index.
 
     Returns
     -------
     gpd.GeoDataFrame
-        Admin boundaries with 'prov_date' and 'prov_idx' columns added.
+        Polygons with 'prov_date' and 'prov_idx' columns added.
+
+    Examples
+    --------
+    # For flood polygons
+    flood_with_prov = add_provenance_to_polygons(flood_polygons, prov_idx, date_mapping)
+
+    # For admin boundaries
+    admin_with_prov = add_provenance_to_polygons(gdf_admin, prov_idx, date_mapping, id_col='adm0_id')
     """
-    logger.info(f"Adding modal provenance to admin level {admin_level} boundaries...")
+    logger.info(f"Adding modal provenance to {len(gdf_polygons)} polygons...")
+
+    # Create temporary ID if none specified
+    if id_col is None:
+        gdf_polygons = gdf_polygons.copy()
+        gdf_polygons['_temp_id'] = range(len(gdf_polygons))
+        id_col = '_temp_id'
+        temp_id_created = True
+    else:
+        temp_id_created = False
 
     # Write provenance raster to temporary file for exactextract
     with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
@@ -497,17 +516,17 @@ def add_modal_provenance_to_admin(gdf_admin: gpd.GeoDataFrame,
         logger.info("  Running exactextract for modal provenance...")
         modal_prov = exactextract.exact_extract(
             tmp_raster_path,
-            gdf_admin,
+            gdf_polygons,
             ["mode", "count"],
-            include_cols=[f"adm{admin_level}_id"],
+            include_cols=[id_col],
             output="pandas",
         )
 
-        # Merge back to admin
-        gdf_result = gdf_admin.merge(
+        # Merge back to polygons
+        gdf_result = gdf_polygons.merge(
             modal_prov,
-            left_on=f"adm{admin_level}_id",
-            right_on=f"adm{admin_level}_id",
+            left_on=id_col,
+            right_on=id_col,
             how="left"
         )
 
@@ -515,13 +534,17 @@ def add_modal_provenance_to_admin(gdf_admin: gpd.GeoDataFrame,
         gdf_result["prov_idx"] = gdf_result["mode"].fillna(-1).astype(int)
         gdf_result["prov_date"] = gdf_result["prov_idx"].map(date_mapping)
 
-        logger.info(f"  ✅ Added provenance to {len(gdf_result)} admin units")
+        # Remove temporary ID if we created one
+        if temp_id_created:
+            gdf_result = gdf_result.drop(columns=['_temp_id'])
+
+        logger.info(f"  ✅ Added provenance to {len(gdf_result)} polygons")
 
         # Log summary
         prov_summary = gdf_result["prov_date"].value_counts()
-        logger.info("  Provenance summary by admin unit:")
+        logger.info("  Provenance summary:")
         for date, count in prov_summary.items():
-            logger.info(f"    {date}: {count} admin units")
+            logger.info(f"    {date}: {count} polygons")
 
         return gdf_result
 


### PR DESCRIPTION
## Auto generate summary
Integrates automatic provenance raster generation into the `scripts/04_generate_flood_polygons.py` pipeline. The provenance raster tracks the last observation date for each flood pixel, enabling temporal analysis and visualization of flood evolution.

## Key Changes

### 1. Provenance Raster Generation ([scripts/04_generate_flood_polygons.py](scripts/04_generate_flood_polygons.py))
- Automatically generates provenance raster after polygon creation
- Uploads to `ds-flood-gfm/processed/provenance_raster/` in blob storage
- Uses same cache key naming convention as polygon outputs
- Format: `{cache_key}_provenance.tif`

### 2. Admin-Level Aggregation Helper ([src/ds_flood_gfm/datasources/gfm.py](src/ds_flood_gfm/datasources/gfm.py))
- Added `add_modal_provenance_to_admin()` function
- Calculates most common (modal) provenance date per admin boundary
- Uses `exactextract` for efficient zonal statistics
- Returns admin GeoDataFrame with `prov_date` and `prov_idx` columns

### 3. Parser Improvements
- Added `--n-search` argument to control STAC search window (default: 15 days)
- Better control over data availability vs processing time trade-off

### 4. Cache Key Naming Update
- Shortened filename format for large date ranges
- Format: `ISO3_YYYYMMDD_to_YYYYMMDD_Ndates_pop_mode`
- Example: `CUB_20251027_to_20251111_16dates_nopop_cumulative`

## Technical Details

### Lazy Evaluation
The provenance raster stays lazy until explicitly computed, minimizing memory usage:
```python
provenance_idx, date_mapping = create_provenance_raster(stack_flood_max, unique_dates)
prov_computed = provenance_idx.compute()  # Only computed when needed
```

### Upload Mechanism
- Uses `stratus.upload_cog_to_blob()` with xarray DataArray directly
- No temporary file creation needed
- Uploads as Cloud Optimized GeoTIFF (COG)

### Date Mapping
Integer indices map to observation dates:
```python
{0: '2025-11-05', 1: '2025-11-08', 2: '2025-11-10', 3: '2025-11-11', -1: 'No Data'}
```

## Testing

Tested successfully on:
- ✅ **Jamaica (JAM)** - Small AOI, 4 dates, cumulative mode
  - Output: `JAM_20251105_20251108_20251110_20251111_nopop_latest_provenance.tif`- **Currently testing on PHL**
## Example Usage

```bash
uv run python scripts/04_generate_flood_polygons.py \
  --iso3 JAM \
  --end-date 2025-11-12 \
  --n-latest 4 \
  --n-search 15 \
  --flood-mode cumulative
```

**Output:**
- Polygons: `ds-flood-gfm/processed/polygon/{cache_key}.shp.zip`
- Provenance: `ds-flood-gfm/processed/provenance_raster/{cache_key}_provenance.tif`

## Visualization

The provenance raster enables visualizations like:
- **Pixel-level:** Color each flood pixel by last observation date (red=oldest, green=newest)
- **Admin-level:** Show modal provenance date for each admin boundary
- **Temporal evolution:** Track how flood extent changes over time

See `demo_provenance_visualization.py` for examples (* will remove or move once pipeline is more thoroughly tested)

## Related Files

- `demo_provenance_visualization.py` - Demo script showing provenance visualization
- `flood_exposure.py` - Updated marimo notebook (added PHL support, minor formatting)